### PR TITLE
Fix broken Windows build and missing tab name colours

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ set(CMAKE_AUTORCC ON)
 add_executable(${PROJECT_NAME} src/main.cpp)
 
 target_sources(${PROJECT_NAME} PRIVATE
+  src/APBFramelessWindow/APBPushButton.cpp
+  src/APBFramelessWindow/APBPushButton.h
   src/MainWindow.cpp
   src/MainWindow.h
   src/MissionList/MissionListItem.cpp
@@ -43,8 +45,6 @@ IF(WIN32)
   target_sources(${PROJECT_NAME} PRIVATE
     src/APBFramelessWindow/APBFramelessWindowTitleBar.cpp
     src/APBFramelessWindow/APBFramelessWindowTitleBar.h
-    src/APBFramelessWindow/APBPushButton.cpp
-    src/APBFramelessWindow/APBPushButton.h
     src/APBFramelessWindow/NativeTranslucentFramelessWindow.cpp
     src/APBFramelessWindow/NativeTranslucentFramelessWindow.h
   )

--- a/src/APBFramelessWindow/APBPushButton.cpp
+++ b/src/APBFramelessWindow/APBPushButton.cpp
@@ -60,8 +60,6 @@ bool APBPushButton::event(QEvent *event) {
 				}
 
 				this->setHighlight(&palette);
-
-				emit this->pressed();
 			}
 
 			break;
@@ -73,8 +71,6 @@ bool APBPushButton::event(QEvent *event) {
 				}
 
 				this->setHighlight(&palette);
-
-				emit this->clicked();
 			}
 
 			break;
@@ -86,14 +82,14 @@ bool APBPushButton::event(QEvent *event) {
 				if(this->timer != nullptr) {
 					this->startTimer(&palette);
 				}
-
-				emit this->released();
 			}
 
 			break;
-		default:
-			return QPushButton::event(event);
+
+    default: {} // Other events are not handled by this switch-statement
 	}
+
+	return QPushButton::event(event);
 }
 
 void APBPushButton::setButtonColour(const QColor &colour) {
@@ -182,7 +178,7 @@ void APBPushButton::paintEvent(QPaintEvent *event) {
 
 	this->setPen(painter);
 
-	auto [outer, inner] = this->drawBox();
+	auto [outer, inner] = this->drawBox(event);
 
 	painter->drawPolygon(outer);
 	painter->setBrush(this->createGradient(inner));
@@ -290,7 +286,7 @@ void APBPushButton::setTitleIcon(TitleIcon icon) {
 	this->titleBarIconType = icon;
 }
 
-std::tuple<QRect, QRect> APBPushButton::drawBox() {
+std::tuple<QRect, QRect> APBPushButton::drawBox(QPaintEvent* event) {
 	// Draw outer box
 	QRect outer = event->rect();
 	// Draw inner box
@@ -299,7 +295,7 @@ std::tuple<QRect, QRect> APBPushButton::drawBox() {
 
 	return {
 		outer, inner
-	}
+	};
 }
 
 void APBPushButton::setPen(QPainter *painter) {
@@ -336,19 +332,19 @@ QLinearGradient APBPushButton::createGradient(const QRect &inner) {
 void APBPushButton::drawTitleBarIcon(QPainter *painter, const QRect &bounds) {
 	switch(this->titleBarIconType) {
 		case TitleIcon::None:
-			this->drawText(painter, inner);
+			this->drawText(painter, bounds);
 			break;
 		case TitleIcon::Minimize:
-			this->drawTitleBarMinimize(painter, inner);
+			this->drawTitleBarMinimize(painter, bounds);
 			break;
 		case TitleIcon::Maximize:
-			this->drawTitleBarMaximize(painter, inner);
+			this->drawTitleBarMaximize(painter, bounds);
 			break;
 		case TitleIcon::Restore:
-			this->drawTitleBarMaximize(painter, inner);
+			this->drawTitleBarMaximize(painter, bounds);
 			break;
 		case TitleIcon::Close:
-			this->drawTitleBarClose(painter, inner);
+			this->drawTitleBarClose(painter, bounds);
 			break;
 	}
 }

--- a/src/APBFramelessWindow/APBPushButton.h
+++ b/src/APBFramelessWindow/APBPushButton.h
@@ -60,7 +60,7 @@ class APBPushButton: public QPushButton {
 	// Element creation
 	QLinearGradient createGradient(const QRect &inner);
 	void setPen(QPainter *painter);
-	std::tuple<QRect, QRect> drawBox();
+	std::tuple<QRect, QRect> drawBox(QPaintEvent* event);
 
 	private slots:
 	// Called whenever QTimeLine is running to lighten and darken button palette

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -5,11 +5,11 @@ MainWindow::MainWindow() {
 
 	// Create import/export buttons
 	auto horizontalButtonLayout = new QHBoxLayout();
-	importButton = new PushButtonBase("Import");
-	exportButton = new PushButtonBase("Export");
+	importButton = new APBPushButton("Import");
+	exportButton = new APBPushButton("Export");
 	exportButton->setDisabled(true);
-	connect(importButton, &PushButtonBase::released, this, &MainWindow::openImportFilesDialog);
-	connect(exportButton, &PushButtonBase::released, this, &MainWindow::exportFiles);
+	connect(importButton, &APBPushButton::released, this, &MainWindow::openImportFilesDialog);
+	connect(exportButton, &APBPushButton::released, this, &MainWindow::exportFiles);
 	horizontalButtonLayout->addWidget(importButton);
 	horizontalButtonLayout->addWidget(exportButton);
 	horizontalButtonLayout->setMargin(0);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -2,6 +2,7 @@
 
 #include <QtWidgets>
 
+#include "APBFramelessWindow/APBPushButton.h"
 #include "MissionList/MissionListItem.h"
 #include "MissionList/MissionListWidget.h"
 #include "StagesEditor/StagesEditorWidget.h"
@@ -10,10 +11,8 @@
 // base classes for the main window and buttons at compile time
 #if defined(_WIN64)
 #include "APBFramelessWindow/NativeTranslucentFramelessWindow.h"
-#include "APBFramelessWindow/APBPushButton.h"
 namespace {
   typedef NativeTranslucentFramelessWindow MainWindowBase;
-  typedef APBPushButton PushButtonBase;
 }
 #elif defined(__linux__) || defined(__MACH__)
 // The Linux/MacOS builds do not support all the UI customizations of the
@@ -21,7 +20,6 @@ namespace {
 // standardized ways to override the client-side decorations
 namespace {
   typedef QWidget MainWindowBase;
-  typedef QPushButton PushButtonBase;
 }
 #endif
 
@@ -40,8 +38,8 @@ protected:
 
 private:
 	const QString applicationName = "Localedit";
-	PushButtonBase *importButton;
-	PushButtonBase *exportButton;
+	APBPushButton *importButton;
+	APBPushButton *exportButton;
 	QLineEdit *search;
 	QCheckBox *nameIdSwitch;
 	MissionListWidget *missions;

--- a/src/StagesEditor/TabWidget/ExpandingTabBar.cpp
+++ b/src/StagesEditor/TabWidget/ExpandingTabBar.cpp
@@ -45,7 +45,7 @@ void ExpandingTabBar::paintEvent(QPaintEvent *paintEvent) {
 
 		// Draw text on tab
 		if(!this->tabText(index).isEmpty()) {
-			this->restorePen(pen, index);
+			this->restorePen(painter, pen, index);
 
 			QRect boundingRect;
 			painter->drawText(tabRect.x() + outerPaintMargin, tabRect.y() + outerPaintMargin,
@@ -80,10 +80,11 @@ QRect ExpandingTabBar::createTabRect(int index) {
 	return tabRect;
 }
 
-void ExpandingTabBar::restorePen(QPen pen, int index) {
+void ExpandingTabBar::restorePen(QPainter* painter, QPen pen, int index) {
 	// Restore pen to draw text
 	pen.setStyle(Qt::PenStyle::SolidLine);
 	auto penColor =
 		index == this->currentIndex() ? this->palette().highlightedText().color() : this->palette().text().color();
 	pen.setColor(penColor);
+  painter->setPen(pen);
 }

--- a/src/StagesEditor/TabWidget/ExpandingTabBar.h
+++ b/src/StagesEditor/TabWidget/ExpandingTabBar.h
@@ -12,7 +12,7 @@ class ExpandingTabBar: public QTabBar {
 	protected:
 	bool event(QEvent *event) override;
 	void paintEvent(QPaintEvent *paintEvent) override;
-	void restorePen(QPen pen, int index);
+	void restorePen(QPainter* painter, QPen pen, int index);
 	void setBrush(QPainter* painter, int index);
 	QRect createTabRect(int index);
 	int outerPaintMargin = 4;


### PR DESCRIPTION
Fixes the currently broken Windows build as a result of merging #1.

Additionally fixes a bug w.r.t. the tab name colours not being updated after the refactor in #3.